### PR TITLE
check fileName and outputDir value is exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,9 @@ class A11yHelper extends Helper {
 
 	async _failed(test: Mocha.Test) {
 		await this.helpers.Playwright.browserContext.close();
-		(test.artifacts as any).a11yReports = resolve(outputDir, fileName);
+		if (fileName && outputDir) {
+			(test.artifacts as any).a11yReports = resolve(outputDir, fileName);
+		}
 		if (allure) {
 			await this._attachArtifacts(test);
 		}
@@ -107,7 +109,9 @@ class A11yHelper extends Helper {
 
 	async _passed(test: Mocha.Test) {
 		await this.helpers.Playwright.browserContext.close();
-		(test.artifacts as any).a11yReports = resolve(outputDir, fileName);
+		if (fileName && outputDir) {
+			(test.artifacts as any).a11yReports = resolve(outputDir, fileName);
+		}
 		if (allure) {
 			await this._attachArtifacts(test);
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,9 +99,7 @@ class A11yHelper extends Helper {
 
 	async _failed(test: Mocha.Test) {
 		await this.helpers.Playwright.browserContext.close();
-		if (fileName && outputDir) {
-			(test.artifacts as any).a11yReports = resolve(outputDir, fileName);
-		}
+		this._handleArtifacts(test);
 		if (allure) {
 			await this._attachArtifacts(test);
 		}
@@ -109,14 +107,18 @@ class A11yHelper extends Helper {
 
 	async _passed(test: Mocha.Test) {
 		await this.helpers.Playwright.browserContext.close();
-		if (fileName && outputDir) {
-			(test.artifacts as any).a11yReports = resolve(outputDir, fileName);
-		}
+		this._handleArtifacts(test);
 		if (allure) {
 			await this._attachArtifacts(test);
 		}
 	}
-
+	
+	_handleArtifacts(test: Mocha.Test) {
+	        if (fileName && outputDir) {
+	            (test.artifacts as any).a11yReports = resolve(outputDir, fileName);
+		}
+	}
+	
 	private async _attachArtifacts(test: Mocha.Test): Promise<void> {
 		const timeString: string = Date.now().toString();
 		const FORMAT: string = "application/zip";


### PR DESCRIPTION
Hi!

Summary
This PR adds a safety check in the _passed() and _failed() methods of the A11yHelper class to prevent errors when runA11yCheck() is not invoked during the test.

Background
Previously, if runA11yCheck() was not called, the fileName variable remained undefined, which caused a runtime error when resolving the a11yReports path:

typescript
Copy
Edit
TypeError: Path must be a string. Received undefined
This happened in the _passed() and _failed() lifecycle hooks when attempting to resolve the accessibility report file path.

Changes
Added conditional checks to ensure that both fileName and outputDir are defined before setting test.artifacts.a11yReports.

This ensures compatibility with tests that do not run the accessibility audit.

